### PR TITLE
Improve responsive layout and navigation

### DIFF
--- a/index.html
+++ b/index.html
@@ -18,6 +18,11 @@
       <span class="logo-dot green"></span>
       <span class="brand-name">Veera</span>
     </div>
+    <button class="menu-toggle" aria-label="Toggle navigation" aria-expanded="false">
+      <span class="menu-bar"></span>
+      <span class="menu-bar"></span>
+      <span class="menu-bar"></span>
+    </button>
     <nav class="nav-links">
       <a href="#home">Home</a>
       <a href="#about">About</a>
@@ -30,7 +35,7 @@
     </div>
   </header>
 
-  <main>
+  <main class="page">
     <section id="home" class="hero">
       <div class="hero-grid surface">
         <div class="hero-text">

--- a/script.js
+++ b/script.js
@@ -41,9 +41,36 @@ function revealOnScroll() {
   document.querySelectorAll('.reveal').forEach(el => observer.observe(el));
 }
 
+function setupNavToggle() {
+  const toggle = document.querySelector('.menu-toggle');
+  const topNav = document.querySelector('.top-nav');
+  const navLinks = document.querySelectorAll('.nav-links a');
+
+  if (!toggle || !topNav) return;
+
+  const closeMenu = () => {
+    topNav.classList.remove('is-open');
+    toggle.setAttribute('aria-expanded', 'false');
+  };
+
+  toggle.addEventListener('click', () => {
+    const open = topNav.classList.toggle('is-open');
+    toggle.setAttribute('aria-expanded', open);
+  });
+
+  navLinks.forEach(link => link.addEventListener('click', closeMenu));
+
+  window.addEventListener('resize', () => {
+    if (window.innerWidth > 860) {
+      closeMenu();
+    }
+  });
+}
+
 document.addEventListener('DOMContentLoaded', () => {
   if (roles.length) {
     updateText();
   }
   revealOnScroll();
+  setupNavToggle();
 });

--- a/style.css
+++ b/style.css
@@ -9,6 +9,7 @@
   --red: #ea4335;
   --yellow: #fbbc05;
   --green: #34a853;
+  --max-width: 1200px;
 }
 
 * {
@@ -23,6 +24,7 @@ body {
   color: var(--text);
   line-height: 1.6;
   scroll-behavior: smooth;
+  min-height: 100vh;
 }
 
 a {
@@ -35,6 +37,16 @@ a {
   box-shadow: var(--shadow);
 }
 
+.page {
+  max-width: var(--max-width);
+  margin: 0 auto;
+  width: min(calc(100% - 1.5rem), var(--max-width));
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+  padding: 0 clamp(1rem, 4vw, 2.5rem) 3rem;
+}
+
 .top-nav {
   position: sticky;
   top: 0;
@@ -43,7 +55,9 @@ a {
   grid-template-columns: auto 1fr auto;
   align-items: center;
   gap: 1.5rem;
-  padding: 1rem 2.5rem;
+  padding: 1rem clamp(1.25rem, 4vw, 2.5rem);
+  margin: 0 auto;
+  width: min(calc(100% - 1.25rem), calc(var(--max-width) + 2.5rem));
   backdrop-filter: blur(10px);
 }
 
@@ -96,6 +110,32 @@ a {
   justify-content: flex-end;
 }
 
+.top-nav.is-open .nav-links,
+.top-nav.is-open .nav-actions {
+  display: flex;
+}
+
+.menu-toggle {
+  display: none;
+  padding: 0.35rem;
+  border: 1px solid #dadce0;
+  background: var(--surface);
+  border-radius: 10px;
+  cursor: pointer;
+  align-items: center;
+  justify-content: center;
+  flex-direction: column;
+  gap: 0.25rem;
+}
+
+.menu-bar {
+  display: block;
+  width: 20px;
+  height: 2px;
+  background: var(--text);
+  border-radius: 999px;
+}
+
 .chip {
   display: inline-flex;
   align-items: center;
@@ -115,14 +155,14 @@ a {
 }
 
 .hero {
-  padding: 3rem 2.5rem 2rem;
+  padding: 3rem 0 2rem;
 }
 
 .hero-grid {
   display: grid;
-  grid-template-columns: 1.2fr 0.8fr;
-  gap: 2rem;
-  padding: 2rem;
+  grid-template-columns: minmax(0, 1.1fr) minmax(320px, 0.9fr);
+  gap: 2.25rem;
+  padding: clamp(1.5rem, 2vw, 2rem);
   border-radius: var(--radius);
 }
 
@@ -134,7 +174,7 @@ a {
 
 .hero-text .lede {
   color: var(--muted);
-  max-width: 46ch;
+  max-width: 52ch;
 }
 
 .eyebrow {
@@ -285,11 +325,10 @@ main {
   display: flex;
   flex-direction: column;
   gap: 1.5rem;
-  padding: 0 2.5rem 3rem;
 }
 
 .section {
-  padding: 2rem;
+  padding: clamp(1.5rem, 2vw, 2.25rem);
   border-radius: var(--radius);
 }
 
@@ -408,6 +447,69 @@ main {
   transform: translateY(0);
 }
 
+@media (min-width: 1280px) {
+  .hero-grid {
+    gap: 2.75rem;
+  }
+
+  .section .project-grid {
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+  }
+}
+
+@media (max-width: 1100px) {
+  .top-nav {
+    width: min(calc(100% - 0.75rem), var(--max-width));
+  }
+
+  .hero-grid {
+    grid-template-columns: 1fr 0.95fr;
+    gap: 1.75rem;
+  }
+
+  .contact-actions {
+    flex-wrap: wrap;
+  }
+}
+
+@media (max-width: 860px) {
+  .top-nav {
+    grid-template-columns: auto auto;
+    align-items: center;
+    row-gap: 0.5rem;
+  }
+
+  .menu-toggle {
+    display: inline-flex;
+    margin-left: auto;
+  }
+
+  .nav-links,
+  .nav-actions {
+    display: none;
+    width: 100%;
+    justify-content: flex-start;
+  }
+
+  .nav-links {
+    flex-direction: column;
+    gap: 0.5rem;
+  }
+
+  .nav-links a {
+    padding: 0.4rem 0.3rem;
+  }
+
+  .nav-actions {
+    flex-direction: column;
+  }
+
+  .cta-row {
+    width: 100%;
+    flex-wrap: wrap;
+  }
+}
+
 @media (max-width: 960px) {
   .hero-grid {
     grid-template-columns: 1fr;
@@ -421,33 +523,29 @@ main {
   .contact-grid {
     grid-template-columns: 1fr;
   }
-
-  .top-nav {
-    grid-template-columns: 1fr;
-    justify-items: flex-start;
-    gap: 0.75rem;
-  }
-
-  .nav-links,
-  .nav-actions {
-    width: 100%;
-    justify-content: flex-start;
-    flex-wrap: wrap;
-  }
 }
 
 @media (max-width: 640px) {
-  .hero,
-  main {
-    padding: 1rem;
+  .page {
+    padding: 0 1rem 2rem;
+  }
+
+  .hero {
+    padding: 2.5rem 0 1.5rem;
   }
 
   .hero-grid,
   .section {
-    padding: 1.25rem;
+    padding: 1rem;
   }
 
   .top-nav {
     padding: 0.75rem 1rem;
+    width: min(calc(100% - 0.5rem), var(--max-width));
+  }
+
+  .nav-actions .chip {
+    width: 100%;
+    justify-content: center;
   }
 }


### PR DESCRIPTION
## Summary
- add a centered page shell and responsive spacing so sections scale across large and small screens
- introduce a mobile-friendly navigation toggle and breakpoints that match tablet and phone layouts
- refine hero, cards, and contact areas to keep typography and grids consistent at desktop sizes

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69514a17c684832aa579fb22132fd9a0)